### PR TITLE
More wide url pattern to work w/ github enterprise

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Octosplit",
   "version": "0.0.7",
-  "description": "Side by side diffs and word wrapping in GitHub",
+  "description": "Side by side diffs and word wrapping in GitHub (and GitHub Enterprise)",
   "manifest_version": 2,
   "icons": {
     "16": "img/icon16.png",
@@ -9,7 +9,8 @@
     "128": "img/icon128.png"
   },
   "content_scripts": [{
-    "matches": ["https://github.com/*/pull/*", "https://github.com/*/commit/*", "https://github.com/*/compare/*"],
+    "matches": ["https://*.com/*/*/pull/*", "https://*.com/*/*/commit/*", "https://*.com/*/*/compare/*"],
+    "include_globs": ["https://github.com/*", "https://github.*.com/*", "https://git.*.com/*"],
     "run_at": "document_end",
     "css": ["css/octosplit.css"],
     "js": ["js/vendor/jquery-1.9.1.min.js", "js/octosplit.js"]


### PR DESCRIPTION
Thank you for this awesome tool!  I am missing it for long time!

My employer has a GitHub Enterprise instance, this change is try to use a wider patten to match our company private hostname as well, I've verified it works for both github and our company instance, though not sure if this change is a good idea...
- Add extra '*/' for best try on url matching
- Use include_globs to match both github and github enterprise (assume their
  hostnames all start with 'github' or 'git' and end with '.com')

Thanks!
Matt
