### PR TITLE
Fix width for side-by-side diffs

### DIFF
--- a/css/octosplit.css
+++ b/css/octosplit.css
@@ -2,11 +2,11 @@
   white-space: normal;
 }
 
-.kill-the-chrome .container.large {
+.container.large {
   width: 98%;
 }
 
-.kill-the-chrome .container.large .repository-content {
+.container.large .repository-content {
   width: 95%
 }
 

--- a/js/octosplit.js
+++ b/js/octosplit.js
@@ -86,11 +86,11 @@ function manageTabs() {
 }
 
 function enlarge() {
-  $('#wrapper .container').addClass('large');
+  $('.wrapper .container').addClass('large');
 }
 
 function shrink() {
-  $('#wrapper .container.large').removeClass('large');
+  $('.wrapper .container.large').removeClass('large');
 }
 
 function splitDiffs() {


### PR DESCRIPTION
`wrapper` is now a _class_, not an _id_ anymore. I didn't know what the `.kill-the-chrome` classes were for, so I deleted them (didn't find the used anywhere in the source).

What would be greatly appreciated would be if word-wrap would work again.
